### PR TITLE
Bugfix/ssl verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # gitlab-artifact-remover
+
+## Links
+[CI/CD](https://circleci.com/gh/Harmannz/workflows/gitlab-artifact-remover)
+
 ## Project setup
 ```
 npm install

--- a/src/components/RemoveForm.vue
+++ b/src/components/RemoveForm.vue
@@ -161,7 +161,9 @@ export default {
     buildRequest(jobId) {
       return axios.post(
         `https://${this.form.baseUrl}/api/v4/projects/${this.form.projectId}/jobs/${jobId}/erase`,
-        {},
+        {
+          rejectUnauthorized: false,
+        },
         {
           headers: {
             'PRIVATE-TOKEN': this.form.token,


### PR DESCRIPTION
Do not verify server certificate. 
This is because GitHub pages will not have the trusted root CA to authorise the certs.

I may add a feature to allow a user to upload their CA.pem.

See:
https://stackoverflow.com/questions/31861109/tls-what-exactly-does-rejectunauthorized-mean-for-me